### PR TITLE
Instalação do MySQL

### DIFF
--- a/Devops.txt
+++ b/Devops.txt
@@ -1,0 +1,3 @@
+Instalação feita com o comando: sudo apt install mysql-server -y.
+o código está instalando o MySQL e dizendo sim para todas as configurações do MySQL.
+resolve #217  

--- a/index.php
+++ b/index.php
@@ -67,3 +67,4 @@ $roteador->post("/produto/editar", "Admin:editarProduto");
 
 // Despacha a requisição atual para a rota correspondente.
 $roteador->dispatch();
+


### PR DESCRIPTION
Instalação feita com o comando: sudo apt install mysql-server  -y.

o código está instalando o MySQL e dizendo sim para todas as configurações do MySQL. reolve #217

esse código foi feito dentro do servidor Ubuntu e instalado com sucesso.